### PR TITLE
Use DOMParser instead of injecting HTML into a div element on the page

### DIFF
--- a/userscripts/SE_global_flag_summary.user.js
+++ b/userscripts/SE_global_flag_summary.user.js
@@ -258,8 +258,8 @@ function loadAccountList() {
  * Parse the network account list.
  */
 function parseNetworkAccounts(html) {
-    let pageNode = document.createElement('div');
-    pageNode.innerHTML = html;
+    let parser = new DOMParser();
+    let pageNode = parser.parseFromString(html, 'text/html');
 
     let accounts = [];
 
@@ -378,8 +378,8 @@ function loadSiteFlagSummary(siteName, siteFlagSummaryUrl, finishedCallback) {
  * Parse the flag summary site and extract the stats.
  */
 function parseSiteFlagSummary(siteName, siteFlagSummaryUrl, html) {
-    let pageNode = document.createElement('div');
-    pageNode.innerHTML = html;
+    let parser = new DOMParser();
+    let pageNode = parser.parseFromString(html, 'text/html');
 
     let sumFlagsTotal = 0;
     let sumFlagsDeclined = 0;


### PR DESCRIPTION
As noted [in this answer on SU](https://superuser.com/a/1484571), the way this script parses HTML by injecting it into a div can trigger side effects such as, most visibly, having the page icon cycle between the favicons of all the accessed SE sites. This parsing method also causes any inline styles and scripts on the parsed pages to be applied to the current page, potentially messing things up.

The solution, which I've been using in my own [SOUP](https://github.com/vyznev/soup) user script for years, is to use [DOMParser](https://developer.mozilla.org/en-US/docs/Web/API/DOMParser) instead. This safely parses the loaded content into a separate DOM tree that isn't linked to the current page DOM in any way.

The attached four-line patch implements this fix. I have tested it on Firefox 69, and it works correctly, eliminating the cycling favicon issue.