### PR TITLE
deprecated flagtracker userscript

### DIFF
--- a/userscripts/README.md
+++ b/userscripts/README.md
@@ -3,7 +3,7 @@
 <sup>Quick install:</sup>  
 [<sup>Stack Exchange Global Flag Summary</sup>](SE_global_flag_summary.user.js?raw=true)  
 [<sup>Helpful Flag Percentage</sup>](helpful_flag_percentage.user.js?raw=true)  
-[<sup>Flag Tracker</sup>](flagtracker.user.js?raw=true)  
+[<sup>Flag Tracker</sup>](https://github.com/SOBotics/Userscripts/raw/master/GenericBot/flagtracker.user.js)  
 
 ---
 
@@ -48,6 +48,8 @@ Fork of [Overall Percentage of Helpful Flags](https://meta.stackoverflow.com/q/3
 ---
 
 ## Flag Tracker
+
+*Deprecated: This Userscript has been moved to the [SOBotics Userscripts repository](https://github.com/SOBotics/Userscripts/tree/master/GenericBot).*
 
 When you flag a post, this userscript will let you monitor that post and notify you in case the post gets edited.
 

--- a/userscripts/flagtracker.meta.js
+++ b/userscripts/flagtracker.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
-// @name          Stack Exchange Flag Tracker
+// @name          Stack Exchange Flag Tracker (Deprecated)
 // @namespace     https://so.floern.com/
-// @version       1.1
+// @version       1.1.1
 // @description   Tracks flagged posts on Stack Exchange.
 // @author        Floern
 // @match         *://*.stackexchange.com/*/*
@@ -17,6 +17,6 @@
 // @require       https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js
 // @grant         GM.xmlHttpRequest
 // @grant         GM_xmlhttpRequest
-// @updateURL     https://raw.githubusercontent.com/Floern/stackoverflow/master/userscripts/flagtracker.meta.js
-// @downloadURL   https://raw.githubusercontent.com/Floern/stackoverflow/master/userscripts/flagtracker.user.js
+// @updateURL     https://github.com/SOBotics/Userscripts/raw/master/GenericBot/flagtracker.user.js
+// @downloadURL   https://github.com/SOBotics/Userscripts/raw/master/GenericBot/flagtracker.user.js
 // ==/UserScript==

--- a/userscripts/flagtracker.user.js
+++ b/userscripts/flagtracker.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
-// @name          Stack Exchange Flag Tracker
+// @name          Stack Exchange Flag Tracker (Deprecated)
 // @namespace     https://so.floern.com/
-// @version       1.1
+// @version       1.1.1
 // @description   Tracks flagged posts on Stack Exchange.
 // @author        Floern
 // @match         *://*.stackexchange.com/*/*
@@ -17,8 +17,8 @@
 // @require       https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js
 // @grant         GM.xmlHttpRequest
 // @grant         GM_xmlhttpRequest
-// @updateURL     https://raw.githubusercontent.com/Floern/stackoverflow/master/userscripts/flagtracker.meta.js
-// @downloadURL   https://raw.githubusercontent.com/Floern/stackoverflow/master/userscripts/flagtracker.user.js
+// @updateURL     https://github.com/SOBotics/Userscripts/raw/master/GenericBot/flagtracker.user.js
+// @downloadURL   https://github.com/SOBotics/Userscripts/raw/master/GenericBot/flagtracker.user.js
 // ==/UserScript==
 
 function computeContentHash(postContent) {


### PR DESCRIPTION
Deprecated the flag tracker userscript instance as it's been moved to the SOBotics userscripts repo.
Minor sctipt update to replace the update/download URL of the script to the new one in the SOBotics repo.