### PR TITLE
SE_global_flag_summary: don't try to load an extra Meta for SO for Agents Meta

### DIFF
--- a/userscripts/SE_global_flag_summary.user.js
+++ b/userscripts/SE_global_flag_summary.user.js
@@ -290,7 +290,7 @@ function parseNetworkAccounts(html) {
         accounts.push({siteName: siteName, flagSummaryUrl: siteFlagSummaryUrl, loadPriority: badgeCount});
 
         // add meta site
-        if (!/(meta\.stackexchange|area51\.stackexchange|stackapps)\.com\//.test(siteFlagSummaryUrl)) {
+        if (!/(meta\.stackexchange|area51\.stackexchange|stackapps|agents\.meta\.stackoverflow)\.com\//.test(siteFlagSummaryUrl)) {
             let metaSiteFlagSummaryUrl;
             if (/\.stackexchange\.com\//.test(siteFlagSummaryUrl)) // SE 2.0 sites
                 metaSiteFlagSummaryUrl = siteFlagSummaryUrl.replace('.stackexchange.com', '.meta.stackexchange.com');


### PR DESCRIPTION
In the list of accounts there is now a "Stack Overflow for Agents Meta" if you sign up for that; it doesn't have a separate Meta Meta, so I added it to the regex of exceptions.